### PR TITLE
New Feature: Iterative Rendering

### DIFF
--- a/Effect-Example/index.html
+++ b/Effect-Example/index.html
@@ -5,7 +5,7 @@
         <meta charset="UTF-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdn.jsdelivr.net/gh/spuckhafte/SpuckJs@0.1.2/Spuck.js"></script>
+        <script src="../Spuck.js"></script>
         <script src="index.js" defer></script>
         <title>State-Example</title>
     </head>

--- a/Effect-Example/index.js
+++ b/Effect-Example/index.js
@@ -10,68 +10,54 @@
 */
 
 // First Button
-// const Button1 = new Spuck({ type: 'button', parent: '#app', id: '1' }).render();
-// const setCount1 = Button1.$state('count1', 0); // set state of the first button
-// Button1.render('re');
+const Button1 = new Spuck({ type: 'button', parent: '#app', id: '1' }).render();
+const setCount1 = Button1.$state('count1', 0); // set state of the first button
+Button1.render('re');
 
-// Button1.prop = { text: 'Clicked: $-count1 times' }; // refer to the state of the first button using "$-" in a string
-// Button1.events = { click: () => setCount1(count => count + 1) }; // change the state of the first button when it is clicked
+Button1.prop = { text: 'Clicked: $-count1 times' }; // refer to the state of the first button using "$-" in a string
+Button1.events = { click: () => setCount1(count => count + 1) }; // change the state of the first button when it is clicked
 
-// Button1.$effect(() => { // effect function for the first button
-//     console.log('Button1 count is: ' + Button1.getState('count1'));
-// }, ['$-count1']); // effect dependency is the state of the first button
+Button1.$effect(() => { // effect function for the first button
+    console.log('Button1 count is: ' + Button1.getState('count1'));
+}, ['$-count1']); // effect dependency is the state of the first button
 
-// Button1.make('re'); // render and mount the first button
+Button1.make('re'); // render and mount the first button
 
-// new Spuck({ type: 'br', parent: '#app' }).make();
-// new Spuck({ type: 'br', parent: '#app' }).make();
+new Spuck({ type: 'br', parent: '#app' }).make();
+new Spuck({ type: 'br', parent: '#app' }).make();
 
-// // Second Button
-// const Button2 = new Spuck({ type: 'button', parent: '#app', id: '2' }).render();
+// Second Button
+const Button2 = new Spuck({ type: 'button', parent: '#app', id: '2' }).render();
 
-// const setCount2 = Button2.$state('count2', 0);
-// Button2.render('re');
+const setCount2 = Button2.$state('count2', 0);
+Button2.render('re');
 
-// Button2.prop = { text: 'Clicked: $-count2 times' };
-// Button2.events = { click: () => setCount2(count => count + 1) };
+Button2.prop = { text: 'Clicked: $-count2 times' };
+Button2.events = { click: () => setCount2(count => count + 1) };
 
-// Button2.$effect(() => {
-//     console.log('Button2 count is: ' + Button2.getState('count2'));
-// }, ['$-count2']);
-// Button2.make('re');
+Button2.$effect(() => {
+    console.log('Button2 count is: ' + Button2.getState('count2'));
+}, ['$-count2']);
+Button2.make('re');
 
-// new Spuck({ type: 'br', parent: '#app' }).make();
-// new Spuck({ type: 'br', parent: '#app' }).make();
+new Spuck({ type: 'br', parent: '#app' }).make();
+new Spuck({ type: 'br', parent: '#app' }).make();
 
 // // Third Button
-// const Button3 = new Spuck({ type: 'button', parent: '#app', id: '3' }).render();
+const Button3 = new Spuck({ type: 'button', parent: '#app', id: '3' }).render();
 
-// Button1.init.pseudoChildren = [Button3]; // set the third button as the pseudo-child of the first button to access its state
-// Button1.render('re');
-// Button2.init.pseudoChildren = [Button3]; // set the third button as the pseudo-child of the second button to access its state too
-// Button2.render('re');
+Button1.init.pseudoChildren = [Button3]; // set the third button as the pseudo-child of the first button to access its state
+Button1.render('re');
+Button2.init.pseudoChildren = [Button3]; // set the third button as the pseudo-child of the second button to access its state too
+Button2.render('re');
 
 // // refer to the pseudo-states (states of the first 2 buttons) of the third button by using "$$-" in a string
-// Button3.prop = { text: 'Button1 count: $$-count1 ; Button2 count: $$-count2' };
-// Button3.attr = { disabled: true };
+Button3.prop = { text: 'Button1 count: $$-count1 ; Button2 count: $$-count2' };
+Button3.attr = { disabled: true };
 
-// Button3.$effect(() => { // effect function for the third button
-//     console.log(`Button3 effected by Button1 (${Button3.getPseudoState('count1')} times) and Button2 (${Button3.getPseudoState('count2')} times)`);
-//     console.log('')
-// }, ['$$-count1', '$$-count2']); // effect depends on its pseudo-states (states of the first 2 buttons)
+Button3.$effect(() => { // effect function for the third button
+    console.log(`Button3 effected by Button1 (${Button3.getPseudoState('count1')} times) and Button2 (${Button3.getPseudoState('count2')} times)`);
+    console.log('')
+}, ['$$-count1', '$$-count2']); // effect depends on its pseudo-states (states of the first 2 buttons)
 
-// Button3.make('re');
-
-
-const NameDisplay = new Spuck({ type: 'h1', parent: '#app', id: 'name-display' }).render();
-
-NameDisplay.init.iterate = ['jhon', 'adam', 'james', 'joe', 'jane', 'sarah', 'jill', 'bob'];
-NameDisplay.$state(':name');
-const setColor = NameDisplay.$state('color', 'red');
-
-NameDisplay.prop = { text: '$$-:name', css: { color: '$-color' } };
-
-NameDisplay.events = { click: () => setColor(color => color === 'black' ? 'red' : 'black') };
-NameDisplay.render('re');
-
-NameDisplay.renderFor();
+Button3.make('re');

--- a/Effect-Example/index.js
+++ b/Effect-Example/index.js
@@ -10,54 +10,68 @@
 */
 
 // First Button
-const Button1 = new Spuck({ type: 'button', parent: '#app', id: '1' }).render();
-const setCount1 = Button1.$state('count1', 0); // set state of the first button
-Button1.render('re');
+// const Button1 = new Spuck({ type: 'button', parent: '#app', id: '1' }).render();
+// const setCount1 = Button1.$state('count1', 0); // set state of the first button
+// Button1.render('re');
 
-Button1.prop = { text: 'Clicked: $-count1 times' }; // refer to the state of the first button using "$-" in a string
-Button1.events = { click: () => setCount1(count => count + 1) }; // change the state of the first button when it is clicked
+// Button1.prop = { text: 'Clicked: $-count1 times' }; // refer to the state of the first button using "$-" in a string
+// Button1.events = { click: () => setCount1(count => count + 1) }; // change the state of the first button when it is clicked
 
-Button1.$effect(() => { // effect function for the first button
-    console.log('Button1 count is: ' + Button1.getState('count1'));
-}, ['$-count1']); // effect dependency is the state of the first button
+// Button1.$effect(() => { // effect function for the first button
+//     console.log('Button1 count is: ' + Button1.getState('count1'));
+// }, ['$-count1']); // effect dependency is the state of the first button
 
-Button1.make('re'); // render and mount the first button
+// Button1.make('re'); // render and mount the first button
 
-new Spuck({ type: 'br', parent: '#app' }).make();
-new Spuck({ type: 'br', parent: '#app' }).make();
+// new Spuck({ type: 'br', parent: '#app' }).make();
+// new Spuck({ type: 'br', parent: '#app' }).make();
 
-// Second Button
-const Button2 = new Spuck({ type: 'button', parent: '#app', id: '2' }).render();
+// // Second Button
+// const Button2 = new Spuck({ type: 'button', parent: '#app', id: '2' }).render();
 
-const setCount2 = Button2.$state('count2', 0);
-Button2.render('re');
+// const setCount2 = Button2.$state('count2', 0);
+// Button2.render('re');
 
-Button2.prop = { text: 'Clicked: $-count2 times' };
-Button2.events = { click: () => setCount2(count => count + 1) };
+// Button2.prop = { text: 'Clicked: $-count2 times' };
+// Button2.events = { click: () => setCount2(count => count + 1) };
 
-Button2.$effect(() => {
-    console.log('Button2 count is: ' + Button2.getState('count2'));
-}, ['$-count2']);
-Button2.make('re');
+// Button2.$effect(() => {
+//     console.log('Button2 count is: ' + Button2.getState('count2'));
+// }, ['$-count2']);
+// Button2.make('re');
 
-new Spuck({ type: 'br', parent: '#app' }).make();
-new Spuck({ type: 'br', parent: '#app' }).make();
+// new Spuck({ type: 'br', parent: '#app' }).make();
+// new Spuck({ type: 'br', parent: '#app' }).make();
 
-// Third Button
-const Button3 = new Spuck({ type: 'button', parent: '#app', id: '3' }).render();
+// // Third Button
+// const Button3 = new Spuck({ type: 'button', parent: '#app', id: '3' }).render();
 
-Button1.init.pseudoChildren = [Button3]; // set the third button as the pseudo-child of the first button to access its state
-Button1.render('re');
-Button2.init.pseudoChildren = [Button3]; // set the third button as the pseudo-child of the second button to access its state too
-Button2.render('re');
+// Button1.init.pseudoChildren = [Button3]; // set the third button as the pseudo-child of the first button to access its state
+// Button1.render('re');
+// Button2.init.pseudoChildren = [Button3]; // set the third button as the pseudo-child of the second button to access its state too
+// Button2.render('re');
 
-// refer to the pseudo-states (states of the first 2 buttons) of the third button by using "$$-" in a string
-Button3.prop = { text: 'Button1 count: $$-count1 ; Button2 count: $$-count2' };
-Button3.attr = { disabled: true };
+// // refer to the pseudo-states (states of the first 2 buttons) of the third button by using "$$-" in a string
+// Button3.prop = { text: 'Button1 count: $$-count1 ; Button2 count: $$-count2' };
+// Button3.attr = { disabled: true };
 
-Button3.$effect(() => { // effect function for the third button
-    console.log(`Button3 effected by Button1 (${Button3.getPseudoState('count1')} times) and Button2 (${Button3.getPseudoState('count2')} times)`);
-    console.log('')
-}, ['$$-count1', '$$-count2']); // effect depends on its pseudo-states (states of the first 2 buttons)
+// Button3.$effect(() => { // effect function for the third button
+//     console.log(`Button3 effected by Button1 (${Button3.getPseudoState('count1')} times) and Button2 (${Button3.getPseudoState('count2')} times)`);
+//     console.log('')
+// }, ['$$-count1', '$$-count2']); // effect depends on its pseudo-states (states of the first 2 buttons)
 
-Button3.make('re');
+// Button3.make('re');
+
+
+const NameDisplay = new Spuck({ type: 'h1', parent: '#app', id: 'name-display' }).render();
+
+NameDisplay.init.iterate = ['jhon', 'adam', 'james', 'joe', 'jane', 'sarah', 'jill', 'bob'];
+NameDisplay.$state(':name');
+const setColor = NameDisplay.$state('color', 'red');
+
+NameDisplay.prop = { text: '$$-:name', css: { color: '$-color' } };
+
+NameDisplay.events = { click: () => setColor(color => color === 'black' ? 'red' : 'black') };
+NameDisplay.render('re');
+
+NameDisplay.renderFor();

--- a/Spuck.js
+++ b/Spuck.js
@@ -5,17 +5,17 @@
 
 class Spuck {
     constructor(init, prop, events, attr) {
-        this.init = init; // {} type:_, parent:_, pseudoChildren[], class[], id:_
+        this.init = init; // {} type:_, parent:_, pseudoChildren[], class[], id:_, iterate[]
         this.prop = prop; // {} text:_, value:_, css{}
-        this.events = events; // {} click:f, mouseover:f, etc.
+        this.events = events; // {} click:f(), mouseover:f(), etc.
         this.attr = attr; // {} value:_, placeholder:_, etc.
-        this._state = {}; // { stateName: [stateValue, changeStateFunction] }
-        this._pseudoState = {}; // { stateName: [stateValue, changeStateFunction] }
-        this.#_effects = {}; // { 1: [effectFunc, [dep]] }
-        this.#_deps = {}; // { '$-state': [value, firstTimeOrNot] }
-        this.#_partialEffects = {}; // { 1: [effectFunc, type] } // type: 'f' or 'e' (first time or everytime)
-        this.#_renderCondition; // function
-        this.#_directMount; // function
+        this._state = {}; // { stateName: [stateValue:_, changeStateFunction()] }
+        this._pseudoState = {}; // { stateName: [stateValue:_, changeStateFunction()] }
+        this.#_effects = {}; // { 1: [effectFunc(), [dep:_$]] }
+        this.#_deps = {}; // { '$-state': [value:_, firstTimeOrNot:?] }
+        this.#_partialEffects = {}; // { 1: [effectFunc(), type:_] } // type: 'f' or 'e' (first time or everytime)
+        this.#_renderCondition; // function()
+        this.#_directMount; // function()
     }
 
     #_SP = '$-' // state prefix
@@ -140,6 +140,27 @@ class Spuck {
     renderIf(condition) {
         this.#_renderCondition = condition;
         return this.render();
+    }
+
+    renderFor() {
+        for (let iter in this.init.iterate) {
+            let _iterate = this.init.iterate[iter];
+            
+            const iterativeStateName = Object.keys(this._state).find(state => state.startsWith(':'));
+            const _pseudoIterativeElement = new Spuck();
+            Object.assign(_pseudoIterativeElement, this);
+
+            delete _pseudoIterativeElement._pseudoState;
+
+            if (iter == this.init.iterate.length - 1) delete _pseudoIterativeElement._state[iterativeStateName];
+
+            _pseudoIterativeElement._pseudoState = {};
+
+            _pseudoIterativeElement._pseudoState[iterativeStateName] = [_iterate];
+
+
+            _pseudoIterativeElement.make();
+        }
     }
 
     mount() { // put the element in dom

--- a/Spuck.js
+++ b/Spuck.js
@@ -152,14 +152,11 @@ class Spuck {
 
             delete _pseudoIterativeElement._pseudoState;
 
-            if (iter == this.init.iterate.length - 1) delete _pseudoIterativeElement._state[iterativeStateName];
-
             _pseudoIterativeElement._pseudoState = {};
-
             _pseudoIterativeElement._pseudoState[iterativeStateName] = [_iterate];
-
-
             _pseudoIterativeElement.make();
+
+            if (iter == this.init.iterate.length - 1) delete _pseudoIterativeElement._state[iterativeStateName];
         }
     }
 


### PR DESCRIPTION
New feature added: `renderFor()`.
This can be used to create iterative elements with similar traits.

Iterating over a data and accessing it was already discussed the beta release, [here](https://github.com/spuckhafte/SpuckJs/releases/tag/v1.1-beta.0)

Now you can also define common states of these iterative elements and work on them individually as all of them gets returned from the `renderFor` function.